### PR TITLE
fix Multi-Attach error

### DIFF
--- a/wordpress-persistent-disks/wordpress.yaml
+++ b/wordpress-persistent-disks/wordpress.yaml
@@ -9,6 +9,11 @@ spec:
   selector:
     matchLabels:
       app: wordpress
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
I will make a PR to [GoogleCloudPlatform/kubernetes-engine-samples](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples) after this [contributing process](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/master/CONTRIBUTING.md#contributing-a-patch)

---

Hello, I am new for kubernetes.
I might find a problem and fix it [here](https://github.com/nao0515ki/kubernetes-engine-samples/pull/1). 
By [Contributing A Patch](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/master/CONTRIBUTING.md#contributing-a-patch), I open Issue first.

### Problem
I got a `Multi-Attach error` at Step 7: Updating application images at [Using Persistent Disks with WordPress and MySQL](https://cloud.google.com/kubernetes-engine/docs/tutorials/persistent-disk).

This is the console log. You can see `Multi-Attach error` at the Message column.
```
$kubectl apply -f wordpress.yaml
deployment.apps/wordpress configured

$kubectl get deployment
NAME        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
mysql       1         1         1            1           1h
wordpress   1         2         1            1           47m

$kubectl get replicasets
NAME                   DESIRED   CURRENT   READY   AGE
mysql-5bfd5f74dd       1         1         1       1h
wordpress-78c9b8d684   1         1         1       48m
wordpress-8648c887dc   1         1         0       4m

$kubectl describe pod wordpress
~~OMISSION~~
Name:               wordpress-8648c887dc-2hcxf
~~OMMISION~~
Containers:
  wordpress:
    Container ID:
    Image:          wordpress:5.1.1
~~OMMISION~~
Events:
  Type     Reason              Age                 From                                                          Message
  ----     ------              ----                ----                                                          -------
  Normal   Scheduled           9m9s                default-scheduler                                             Successfully assigned default/wordpress-8648c887dc-2hcxf to gke-persistent-disk-tuto-default-pool-f0cd3ac1-htwh
  Warning  FailedAttachVolume  9m9s                attachdetach-controller                                       Multi-Attach error for volume "pvc-740f57ab-496c-11e9-aa81-42010a92023f" Volume is already used by pod(s) wordpress-78c9b8d684-vr9zd
  Warning  FailedMount         21s (x4 over 7m6s)  kubelet, gke-persistent-disk-tuto-default-pool-f0cd3ac1-htwh  Unable to mount volumes for pod "wordpress-8648c887dc-2hcxf_default(2a78750e-4986-11e9-aa81-42010a92023f)": timeout expired waiting for volumes to attach or mount for pod "default"/"wordpress-8648c887dc-2hcxf". list of unmounted volumes=[wordpress-persistent-storage]. list of unattached volumes=[wordpress-persistent-storage default-token-9swck]
```

### The cause
The `accessModes` of `wordpress-volumeclaim` is `ReadWriteOnce`.
But, k8s try to connect by both of containers.

### Solution
Change the strategy of rolling update.
please see the code.